### PR TITLE
Add Luxembourgish (`lb`)

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -410,6 +410,10 @@
       nativeName: "Latin",
       englishName: "Latin"
     },
+    'lb': {
+      nativeName: "Lëtzebuergesch",
+      englishName: "Luxembourgish"
+    },
     'li-NL': {
       nativeName: "Lèmbörgs",
       englishName: "Limburgish"


### PR DESCRIPTION
Part of BCP47: http://schneegans.de/lv/?tags=lb&format=text

```
Input
lb
Canonical
lb
Input is canonical
True
Well-formed
True
Valid
True
Registry date
2015-12-16
Primary language subtag
lb – Luxembourgish; Letzeburgesch
```