### PR TITLE
Fix spanish names in a couple of spanish locales

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -199,7 +199,7 @@
       englishName: "Spanish (Argentina)"
     },
     'es-419': {
-      nativeName: "Español (Latino America)",
+      nativeName: "Español (Latinoamérica)",
       englishName: "Spanish (Latin America)"
     },
     'es-CL': {
@@ -219,8 +219,8 @@
       englishName: "Spanish (Spain)"
     },
     'es-LA': {
-      nativeName: "Español",
-      englishName: "Spanish (Latin)"
+      nativeName: "Español (Latinoamérica)",
+      englishName: "Spanish (Latin America)"
     },
     'es-NI': {
       nativeName: "Español (Nicaragua)",

--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -215,7 +215,7 @@
       englishName: "Spanish (Latin)"
     },
     'es-NI': {
-      nativeName: "Español Nicaragüense",
+      nativeName: "Español (Nicaragua)",
       englishName: "Spanish (Nicaragua)"
     },
     'es-MX': {


### PR DESCRIPTION
Español nicaragüense to Español (Nicaragua) and both Latin and Latino America to Latinoamérica.