### PR TITLE
Klingon is tlh, not tl

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -758,7 +758,7 @@
       nativeName: "Filipino",
       englishName: "Filipino"
     },
-    'tl-ST': {
+    'tlh': {
       nativeName: "tlhIngan-Hol",
       englishName: "Klingon"
     },


### PR DESCRIPTION
Otherwise it would be "Filipino from São Tomé and Príncipe"
(https://en.wikipedia.org/wiki/Klingon_language)