### PR TITLE
Add 'vi' and 'tg' locales

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -742,6 +742,10 @@
       nativeName: "తెలుగు",
       englishName: "Telugu"
     },
+    'tg': {
+      nativeName: "забо́ни тоҷикӣ́",
+      englishName: "Tajik"
+    },
     'tg-TJ': {
       nativeName: "тоҷикӣ",
       englishName: "Tajik"
@@ -801,6 +805,10 @@
     'uz-UZ': {
       nativeName: "O'zbek",
       englishName: "Uzbek"
+    },
+    'vi': {
+      nativeName: "Tiếng Việt",
+      englishName: "Vietnamese"
     },
     'vi-VN': {
       nativeName: "Tiếng Việt",


### PR DESCRIPTION
Vietnamese found from https://product-details.mozilla.org/1.0/languages.json
Tajik found here: https://github.com/mozilla/thimble.mozilla.org/issues/1950#issuecomment-294898361