### PR TITLE
name of the Irish language

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -331,8 +331,8 @@
       englishName: "Irish"
     },
     'ga-IE': {
-      nativeName: "Gaeilge (Gaelic)",
-      englishName: "Irish (Gaelic)"
+      nativeName: "Gaeilge",
+      englishName: "Irish"
     },
     'gl': {
       nativeName: "Galego",


### PR DESCRIPTION
The names (both English and native) of `ga-IE` here are nonsensical. I propose to change `ga-IE` and to make it the same as `ga` because `IE` is the default country for `ga`.

For more information on the Irish language and its name(s), see for example here: http://www.lexiconista.com/pdf/LocalizationWithIrish.pdf

Thank you.