### PR TITLE
Added the living Celtic languages that were not already included

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -86,6 +86,10 @@
       nativeName: "বাংলা(বাংলাদেশ)",
       englishName: "Bengali (Bangladesh)"
     },
+    'br': {
+      nativeName: "Brezhoneg",
+      englishName: "Breton"
+    }
     'bs-BA': {
       nativeName: "Bosanski",
       englishName: "Bosnian"
@@ -334,6 +338,10 @@
       nativeName: "Gaeilge (Gaelic)",
       englishName: "Irish (Gaelic)"
     },
+    'gd': {
+      nativeName: "Gàidhlig",
+      englishName: "Gaelic"
+    },
     'gl': {
       nativeName: "Galego",
       englishName: "Galician"
@@ -349,6 +357,10 @@
     'gu-IN': {
       nativeName: "ગુજરાતી",
       englishName: "Gujarati"
+    },
+    'gv': {
+      nativeName: "Gaelg",
+      englishName: "Manx"
     },
     'gx-GR': {
       nativeName: "Ἑλληνική ἀρχαία",
@@ -473,6 +485,10 @@
     'ku-TR': {
       nativeName: "Kurdî",
       englishName: "Kurdish"
+    },
+    'kw': {
+      nativeName: "Kernewek",
+      englishName: "Cornish"
     },
     'la': {
       nativeName: "Latin",


### PR DESCRIPTION
Although Irish and Welsh already had entries, the other four did not.

I have only added the base two-letter language codes, on the assumption that people who are directly involved in those communities will add the the four-letter codes if desired.