### PR TITLE
Electron 10 missing languages

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -410,9 +410,13 @@
       nativeName: "Magyar",
       englishName: "Hungarian"
     },
-    'hy-AM': {
+    'hy': {
       nativeName: "Հայերեն",
       englishName: "Armenian"
+    },
+    'hy-AM': {
+      nativeName: "Հայերեն (Հայաստան)",
+      englishName: "Armenian (Armenia)"
     },
     'id': {
       nativeName: "Bahasa Indonesia",

--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -302,9 +302,13 @@
       nativeName: "Suomi",
       englishName: "Finnish"
     },
-    'fo-FO': {
+    'fo': {
       nativeName: "Føroyskt",
       englishName: "Faroese"
+    },
+    'fo-FO': {
+      nativeName: "Føroyskt (Færeyjar)",
+      englishName: "Faroese (Faroe Islands)"
     },
     'fr': {
       nativeName: "Français",


### PR DESCRIPTION
Hi,

I'm using Electron 10 and its integrated spelling checker.
In supported languages, the two ones of this pull request are missing in your library.
Could you add them ?

Best regards,
CYOSP