### PR TITLE
Fix syntax error (missing comma)

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -89,7 +89,7 @@
     'br': {
       nativeName: "Brezhoneg",
       englishName: "Breton"
-    }
+    },
     'bs-BA': {
       nativeName: "Bosanski",
       englishName: "Bosnian"


### PR DESCRIPTION
There is a missing comma, and the module cannot be parsed.

To reproduce:

```
git clone https://github.com/mozilla/language-mapping-list.git
node -e "require('./language-mapping-list/language-mapping-list')"
```

Error:
```
C:\Users\rschm\code\language-mapping-list\language-mapping-list.js:93
    'bs-BA': {
    ^^^^^^^

SyntaxError: Unexpected string
```