### PR TITLE
fix: correct the native name of sinhala

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -691,7 +691,7 @@
       englishName: "Serbo-Croatian"
     },
     'si-LK': {
-      nativeName: "පළාත",
+      nativeName: "සිංහල",
       englishName: "Sinhala (Sri Lanka)"
     },
     'sk': {


### PR DESCRIPTION
The native name of Sinhala should be `සිංහල` not `පළාත`.  In Sinhala, `පළාත` means a province.