### PR TITLE
Add en-SG to the language display mapping list

### DIFF
--- a/language-mapping-list.js
+++ b/language-mapping-list.js
@@ -190,6 +190,10 @@
       nativeName: "English (Pirate)",
       englishName: "English (Pirate)"
     },
+    'en-SG': {
+      nativeName: "English (Singapore)",
+      englishName: "English (Singapore)"
+    },
     'en-UD': {
       nativeName: "English (Upside Down)",
       englishName: "English (Upside Down)"


### PR DESCRIPTION
Because en-SG is a variant of English that should be included in this list.